### PR TITLE
Modified to handle allowas,sender side detect and other AF configs fo…

### DIFF
--- a/templates/dellos10_bgp.j2
+++ b/templates/dellos10_bgp.j2
@@ -390,6 +390,7 @@ router bgp {{ bgp_vars.asn }}
               {% endif %}
           {% endif %}
           {% if neighbor.interface is defined and neighbor.interface %}
+            {% set tag_or_ip = neighbor.interface %}
               {% if neighbor.state is defined and neighbor.state == "absent" %}
  no neighbor interface {{ neighbor.interface }}
               {% else %}
@@ -414,43 +415,6 @@ router bgp {{ bgp_vars.asn }}
                   {% elif neighbor.peergroup_type is defined %}
   inherit template {{ neighbor.peergroup }} inherit-type {{ neighbor.peergroup_type }}
                   {% endif %}
-                {% endif %}
-                {% if neighbor.send_community is defined and neighbor.send_community %}
-                  {% for comm in neighbor.send_community %}
-                    {% if comm.type is defined and comm.type %}
-                      {% if comm.state is defined and comm.state == "absent" %}
-                      no send-community {{ comm.type }}
-                      {% else %}
-                      send-community {{ comm.type }}
-                      {% endif %}
-                    {% endif %}
-                  {% endfor %}
-                {% endif %}
-                {% if neighbor.address_family is defined and neighbor.address_family %}
-                  {% for af in neighbor.address_family %}
-                    {% if af.type is defined and af.type %}
-                      {% if af.state is defined and af.state == "absent" %}
-                        {% if af.type == "l2vpn" %}
-                        no address-family {{ af.type }} evpn
-                        {% else %}
-                        no address-family {{ af.type }} unicast
-                        {% endif %}
-                      {% else %}
-                        {% if af.type == "l2vpn" %}
-                         address-family {{ af.type }} evpn
-                        {% else %}
-                         address-family {{ af.type }} unicast
-                        {% endif %}
-                        {% if af.activate is defined %}
-                          {% if af.activate %}
-                          activate
-                          {% else %}
-                          no activate
-                          {% endif %}
-                        {% endif %}
-                      {% endif %}
-                    {% endif %}
-                  {% endfor %}
                 {% endif %}
               {% endif %}
           {% endif %}
@@ -559,6 +523,13 @@ router bgp {{ bgp_vars.asn }}
    activate
                       {% else %}
    no activate
+                      {% endif %}
+                    {% endif %}
+                    {% if af.sender_loop_detect is defined %}
+                      {% if af.sender_loop_detect %}
+   sender-side-loop-detection
+                      {% else %}
+   no sender-side-loop-detection
                       {% endif %}
                     {% endif %}
                     {% if af.allow_as_in is defined %}


### PR DESCRIPTION
Issue:

allow_as_in and sender_loop_detect configs under Address family were not generated.Neighbor level configs were not also not getting generated other than send_community

Fix:
{% set tag_or_ip = neighbor.interface %}
There is a section in template which handles configs supported under many contexts meaning

1)weight is supported under template and peer level
2)sender_side_loop_detection is supported under all address families.

Setting this tag to unnum interface name takes care of legacy features supported in BGP.

Please have a look at the pull request raised for gitlab repo below..
https://gitlab.force10networks.com/INNO/lothlorien/merge_requests/144
